### PR TITLE
ADD[241]:jenkins  add example pipeline to run 2 stages in parallel

### DIFF
--- a/topics/jenkins/helloworld/PipelineWithParallelStages.groovy
+++ b/topics/jenkins/helloworld/PipelineWithParallelStages.groovy
@@ -1,0 +1,22 @@
+pipeline {
+    agent any
+    stages {
+        stage('ParallelStage1') {
+            steps {
+                // Print a message
+                echo "This is ParallelStage1"
+            }
+        }
+        stage('ParallelStage2') {
+            steps {
+                // Print a message
+                echo "This is ParallelStage2"
+            }
+        }
+    }
+    parallel {
+        // Run the ParallelStage1 and ParallelStage2 stages in parallel
+        stage 'ParallelStage1'
+        stage 'ParallelStage2'
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->
Closes: #241 
> *Be noted that #241  is the issue ID*

## What is the purpose of the change
To add a new pipeline script to the devops-basic repository that runs two stages in parallel.
To provide an example of how to use parallel stages in a Jenkins pipeline.
To make the devops-basic repository more comprehensive and informative.

## Add a description of the overall background and high level changes that this PR introduces

>This PR introduces a new pipeline script to the devops-basic repository called PipelineWithParallelStages.groovy.
This pipeline script runs two stages in parallel, ParallelStage1 and ParallelStage2.
Each stage simply prints a message to the console.
This pipeline script is a simple example of how to use parallel stages in a Jenkins pipeline.