### PR TITLE
jenkins: naming the jenkins docker compose stack #274

### DIFF
--- a/topics/jenkins/deploy/docker-compose/docker-compose.yml
+++ b/topics/jenkins/deploy/docker-compose/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.7'
+name: jenkins
 services:
   jenkins:
     image: jenkins/jenkins:lts


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


> *Be noted that #274 is the issue ID*

## What is the purpose of the change


>This PR changes the name of the Jenkins Docker Compose stack from default to jenkins. This makes the stack name more descriptive and easier to identify. It also makes the stack name consistent with the Jenkins CI/CD project name, which is also jenkins.

>This change is relatively minor, but it is a good practice to name Docker Compose stacks in a clear and consistent way. This makes it easier to manage and monitor the stacks, and it also makes it easier for other team members to understand what the stacks are doing.

