### PR TITLE
ADD[#133]: Add docker cheatsheet link

### DIFF
--- a/topics/docker/README.md
+++ b/topics/docker/README.md
@@ -10,3 +10,5 @@
 - [Docker Hands on example](./hands-on/)
 # Docker Helloword:
 - Run [docker-helloworld.sh](./docker-helloworld.sh)
+# Docker cheatsheet
+- [Docker cheatsheet](https://docs.docker.com/get-started/docker_cheatsheet.pdf)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

> *Be noted that 133 is the issue ID*

## What is the purpose of the change

> This pull request adds a link to the Docker cheatsheet to the README.md file in the topic/docker directory. This will provide users with a quick and easy way to access comprehensive information about Docker.

Adding a link to the Docker cheatsheet to the README.md file in the topic/docker directory will make it easier for users to find and use this resource. This will help users to learn more about Docker and to use it to build and deploy their applications.
