### PR TITLE
FIX[#224]:shell check for prometheus folder failed

### DIFF
--- a/topics/prometheus/hello-world/prometheus-helloworld-cleanup.sh
+++ b/topics/prometheus/hello-world/prometheus-helloworld-cleanup.sh
@@ -6,19 +6,19 @@ console_log() {
 
 kill_port() {
   local port_fwd=$1
-  ### Run the ps -ef command and use grep to filter the output for 'port-forward'
-  process_line=$(ps -ef | grep 'port-forward' | grep "$port_fwd" | grep -v grep)
+  ### Run the pgrep command to find the process ID for 'port-forward'
+  process_line=$(pgrep -f "port-forward.*$port_fwd")
   ### Extract the PID from the process_line using awk or cut
-  PID=$(echo "$process_line" | awk '{print $2}') # Using awk
+  PID="$process_line" # Using awk
   console_log "Killing $PID"
   kill -9 $PID
 }
 
 uninstall_chart() {
   local char_name=$1
-  helm uninstall $char_name
+  helm uninstall "$char_name"
 }
 
 console_log "Cleanup Prometheus Demo!"
-kill_port $1
-uninstall_chart $2
+kill_port "$1"
+uninstall_chart "$2"

--- a/topics/prometheus/hello-world/prometheus-helloworld.sh
+++ b/topics/prometheus/hello-world/prometheus-helloworld.sh
@@ -54,12 +54,7 @@ console_log "Now visit your own Prometheus server URL"
 console_log "[Search] Under the Search Expression, inpout 'container_cpu_load_average_10s'"
 console_log "[Execute] Then hit the 'Execute' button on the right hand side"
 console_log "[Result] You would see the result like:"
-sample_result_output="""
-  container_cpu_usage_seconds_total{beta_kubernetes_io_arch="amd64", 
-  beta_kubernetes_io_os="linux", cpu="total", id="/", instance="docker-desktop", 
-  job="kubernetes-nodes-cadvisor", kubernetes_io_arch="amd64",
-  kubernetes_io_hostname="docker-desktop", kubernetes_io_os="linux"}
-  2334.7130145"""
+sample_result_output=$'container_cpu_usage_seconds_total{beta_kubernetes_io_arch="amd64", \n  beta_kubernetes_io_os="linux", cpu="total", id="/", instance="docker-desktop", \n  job="kubernetes-nodes-cadvisor", kubernetes_io_arch="amd64",\n  kubernetes_io_hostname="docker-desktop", kubernetes_io_os="linux"}\n  2334.7130145'
 console_log "[Result] $sample_result_output"
 
 console_log "Congrats! You did the first hands-on with Prometheus 🎉"
@@ -70,5 +65,5 @@ if [[ "$CLEANUP_AFTER_DEMO" == "true" ]]; then
   console_log "Cleanup completed!"
 else
   console_log "Option cleanup after the demo is not set. You can cleanup the resource in this hands-on by running:"
-  console_log "./prometheus-helloworld-cleanup.sh "$port_fwd" "$PROMETHEUS_NAME""
+  console_log "./prometheus-helloworld-cleanup.sh \"$port_fwd\" \"$PROMETHEUS_NAME\""
 fi


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #224
> *Be noted that 224 is the issue ID*

## What is the purpose of the change

>This pull request improves the shell scripts `prometheus-helloworld-cleanup.sh` and `prometheus-helloworld.sh` in the `tungbq/devops-basic` repository by addressing ShellCheck warnings. The changes enhance the scripts' robustness and maintainability by adhering to best practices for Bash scripting.

The specific improvements include:
- Replacing `ps -ef | grep 'port-forward'` with `pgrep -f "port-forward.*$port_fwd"` for more efficient process ID retrieval.
- Adding double quotes around variable references to prevent globbing and word splitting, which can lead to unexpected behavior.
- Correcting the form of string concatenation to avoid ambiguity.
- Ensuring all double quoted strings are properly closed to prevent syntax errors.

These changes contribute to cleaner, safer, and more reliable code. They also ensure that the scripts adhere to widely accepted best practices for Bash scripting, thereby making the code easier to read and maintain.

