### PR TITLE
ADD[#245]: CI workflow to automate labeling issues/PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,43 @@
+name: Label issue/PR
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get issue/PR title
+        id: get_title
+        run: |
+          echo "::set-output name=title::$(gh pr view --json title --jq '.title'")
+
+      - name: Check if title matches defined list
+        id: check_title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const supportedLabels = ["doc", "jenkins", "enhancement"];
+            const title = ${{ steps.get_title.outputs.title }};
+            const labels = title.split(/[\s/]+/);
+
+            for (const label of labels) {
+              if (!supportedLabels.includes(label)) {
+                return "Title does not match supported labels";
+              }
+            }
+
+            return labels;
+
+      - name: Add labels to issue/PR
+        if: ${{ steps.check_title.outputs.result != 'Title does not match supported labels' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = ${{ steps.check_title.outputs.result }};
+
+            gh issue add-labels ${{ github.issue.number }} ${labels.join(' ')}

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Check if title matches defined list
         id: check_title
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           script: |
             const supportedLabels = ["doc", "jenkins", "enhancement"];
@@ -35,7 +35,7 @@ jobs:
 
       - name: Add labels to issue/PR
         if: ${{ steps.check_title.outputs.result != 'Title does not match supported labels' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           script: |
             const labels = ${{ steps.check_title.outputs.result }};


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #245
> *Be noted that 245 is the issue ID*

## What is the purpose of the change

>The following changes were made to the code in the .github/workflows/label.yml file:

>Added a new step called check_title that checks if the issue/PR title matches any of the defined labels.
Added a new if statement to the add_labels step that ensures that the labels are only added if the issue/PR title matches a defined label.
Updated the add_labels step to use the gh issue add-labels command instead of the gh pr add-labels command, since the workflow is now being triggered for both issues and pull requests.

*Benefits:
The new CI workflow will provide the following benefits:
It will help to keep issues and pull requests well-organized and make it easier for developers to find the information they need.
It will reduce the amount of manual work that developers need to do to label issues and pull requests.
It will make it easier to enforce labeling standards across the repository. *
