### PR TITLE
fixed typo in topics > jenkins > readme

### DIFF
--- a/topics/jenkins/README.md
+++ b/topics/jenkins/README.md
@@ -7,5 +7,5 @@
 # Install Jenkins with Helm
 - See [deploy-jenkins/README.md](../helm/hands-on/deploy-jenkins/README.md)
 
-# Jenkins Helloword Hands on
+# Jenkins Helloworld Hands on
 - See: [Jenkins Hello world](./helloworld/Jenkins-Hello-World.md)


### PR DESCRIPTION
Closes: #333

## There existed a typo in a readme file

This pull request improves documentation of area A by fixing a typo in topics > jenkins > readme
