### PR TITLE
Fixed typo in Packer link #405

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Groovy |  [groovy](./topics/groovy/)| 📖 [groovy-lang.org](https://groovy-lang.org/documentation.html)|✔️ [groovy/helloworld](./topics/groovy/helloworld/)|
 | Prometheus |  [prometheus](./topics/prometheus/)| 📖 [prometheus.io/docs](https://prometheus.io/docs/)|✔️ [prometheus-helloworld.sh](./topics/prometheus/hello-world/prometheus-helloworld.sh)|
 | Python |  [python](./topics/python/)| 📖 [www.python.org/doc](https://www.python.org/doc/)|✔️ [python/helloworld](./topics/python/helloworld/)|
-| Packer |  comming-soon| 📖 [www.packer.io](https://www.packer.io/)|comming-soon|
+| Packer |  coming-soon| 📖 [www.packer.io](https://www.packer.io/)|coming-soon|
 
 ## Extra content (from other repos)
 | Item | Link |


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #405 

## What is the purpose of the change

This Pull Request fixes a small typo in README.md regarding the Packer link. I have changed the words 'comming-soon' to 'coming-soon'.

## Screenshot

![Screenshot 2024-01-06 124725](https://github.com/tungbq/devops-basic/assets/117531461/a1e20b37-aa3f-444c-8fda-ae22c31e0141)

