### PR TITLE
Add official github link to argocd README

### DIFF
--- a/topics/argocd/README.md
+++ b/topics/argocd/README.md
@@ -2,6 +2,10 @@
 
 - https://argo-cd.readthedocs.io/en/stable/#what-is-argo-cd
 
+# Argo CD Official GitHub repo
+
+- https://github.com/argoproj/argo-cd
+
 # Why Argo CD?
 
 - https://argo-cd.readthedocs.io/en/stable/#why-argo-cd


### PR DESCRIPTION
Closes: #408 

## What is the purpose of the change
The pull request fixes a small change in the argocd README regarding the linking to the official GitHub repository of argo-cd. I have added the correct link for the same.

## Screenshot
![image](https://github.com/tungbq/devops-basic/assets/86654557/5a2c4725-64fd-42f4-9bba-aa3326391187)