### PR TITLE
docs: fixed typo in docker README

### DIFF
--- a/topics/docker/README.md
+++ b/topics/docker/README.md
@@ -8,7 +8,7 @@ Docker is a platform designed to make it easier to create, deploy, and run appli
 
 For a deeper understanding, refer to the [Docker Architecture documentation](https://docs.docker.com/get-started/overview/#docker-architecture).
 
-### Official website documentation of YOUR_TOPIC
+### Official website documentation of docker
 
 - Access the complete [official Docker documentation](https://docs.docker.com) for detailed information and references.
 


### PR DESCRIPTION
Closes: #441 docker: fix typo in README.md

## What is the purpose of the change

This pull request changes `Official website documentation of YOUR_TOPIC` to `Official website documentation of docker`
in https://github.com/tungbq/devops-basic/tree/main/topics/docker#official-website-documentation-of-your_topic