### PR TITLE
Fix broken GitHub profile link in contributors list

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -144,15 +144,6 @@
       ]
     },
     {
-      "login": "dcompanykrish",
-      "name": "vivekvr",
-      "avatar_url": "https://avatars.githubusercontent.com/u/99336923?v=4",
-      "profile": "https://github.com/dcompanykrish",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
       "login": "mariuszmichalowski",
       "name": "Mariusz Michalowski",
       "avatar_url": "https://avatars.githubusercontent.com/u/92091891?v=4",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: # Fixes #332


## Fix broken GitHub profile link in contributors list

> 
-  dcompanykrish has updated his profile URL to https://github.com/vivekvr1 which is already added as new entry
- Fixed broken GitHub profile link: https://github.com/dcompanykrish from removing the renamed account details
- Updated .all-contributorsrc
- This resolves the link checker failure in issue #332


*My first ever contribution!😅*
